### PR TITLE
feat: cached engagement data model + threshold settings (Issue #2)

### DIFF
--- a/block_student_engagement.php
+++ b/block_student_engagement.php
@@ -59,6 +59,8 @@ class block_student_engagement extends block_base {
      * @return stdClass
      */
     public function get_content(): stdClass {
+        global $COURSE, $DB;
+
         if ($this->content !== null) {
             return $this->content;
         }
@@ -76,7 +78,41 @@ class block_student_engagement extends block_base {
             return $this->content;
         }
 
-        $this->content->text = get_string('contentnotready', 'block_student_engagement');
+        // Cache-first read: this issue introduces the persistence model and fast runtime reads.
+        // Calculation (reading logstore_standard_log) will be implemented separately.
+        $courseid = isset($COURSE->id) ? (int)$COURSE->id : 0;
+        $cache = null;
+        if ($courseid > 0) {
+            $cache = \block_student_engagement\cache_manager::get_course_cache($courseid);
+        }
+
+        if (!$cache) {
+            $this->content->text = get_string('cachenotavailable', 'block_student_engagement');
+            return $this->content;
+        }
+
+        $mostactiveuser = '-';
+        if (!empty($cache->most_active_userid)) {
+            $user = $DB->get_record('user', ['id' => (int)$cache->most_active_userid],
+                'id,firstname,lastname,firstnamephonetic,lastnamephonetic,middlename,alternatename', IGNORE_MISSING);
+            if ($user) {
+                $mostactiveuser = fullname($user);
+            }
+        }
+
+        $lastcalculated = !empty($cache->last_calculated) ? userdate((int)$cache->last_calculated) : '-';
+
+        $rows = [];
+        $rows[] = html_writer::tag('dt', get_string('active_students', 'block_student_engagement'));
+        $rows[] = html_writer::tag('dd', (int)$cache->active_students);
+        $rows[] = html_writer::tag('dt', get_string('inactive_students', 'block_student_engagement'));
+        $rows[] = html_writer::tag('dd', (int)$cache->inactive_students);
+        $rows[] = html_writer::tag('dt', get_string('most_active_user', 'block_student_engagement'));
+        $rows[] = html_writer::tag('dd', s($mostactiveuser));
+        $rows[] = html_writer::tag('dt', get_string('last_calculated', 'block_student_engagement'));
+        $rows[] = html_writer::tag('dd', s($lastcalculated));
+
+        $this->content->text = html_writer::tag('dl', implode('', $rows), ['class' => 'block_student_engagement_metrics']);
         return $this->content;
     }
 }

--- a/classes/cache_manager.php
+++ b/classes/cache_manager.php
@@ -1,0 +1,155 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cache manager for Student Engagement metrics.
+ *
+ * This class encapsulates all persistence concerns for cached engagement
+ * metrics by course, so block rendering can stay fast and predictable.
+ *
+ * @package    block_student_engagement
+ * @copyright  2026 Bastian Coquedano
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_student_engagement;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Helper for reading/writing the engagement cache table.
+ */
+class cache_manager {
+
+    /** @var string The cache table name (without prefix). */
+    private const TABLE = 'block_student_engagement_cache';
+
+    /**
+     * Insert or update cached engagement metrics for a course.
+     *
+     * Expected keys/props (minimum): courseid.
+     * Optional: active_students, inactive_students, most_active_userid,
+     * most_active_interactions, inactive_userids (array|string), last_calculated.
+     *
+     * @param array|\stdClass $data
+     * @return int The record id (inserted or existing).
+     */
+    public static function save_course_engagement($data): int {
+        global $DB;
+
+        $record = self::normalise_record($data);
+
+        $existing = $DB->get_record(self::TABLE, ['courseid' => $record->courseid], 'id', IGNORE_MISSING);
+        if ($existing) {
+            $record->id = (int)$existing->id;
+            $DB->update_record(self::TABLE, $record);
+            return $record->id;
+        }
+
+        return (int)$DB->insert_record(self::TABLE, $record);
+    }
+
+    /**
+     * Get the cached engagement record for a course.
+     *
+     * @param int $courseid
+     * @return \stdClass|null
+     */
+    public static function get_course_cache(int $courseid): ?\stdClass {
+        global $DB;
+
+        $courseid = (int)$courseid;
+        if ($courseid <= 0) {
+            return null;
+        }
+
+        return $DB->get_record(self::TABLE, ['courseid' => $courseid], '*', IGNORE_MISSING) ?: null;
+    }
+
+    /**
+     * Get all cached engagement records.
+     *
+     * @return array<int,\stdClass> Records keyed by id.
+     */
+    public static function get_all_cached_courses(): array {
+        global $DB;
+
+        return $DB->get_records(self::TABLE, null, 'courseid ASC');
+    }
+
+    /**
+     * Clear cache records.
+     *
+     * @param int|null $courseid If null, clears the whole cache table.
+     * @return void
+     */
+    public static function clear_cache(?int $courseid = null): void {
+        global $DB;
+
+        if ($courseid === null) {
+            $DB->delete_records(self::TABLE);
+            return;
+        }
+
+        $courseid = (int)$courseid;
+        if ($courseid <= 0) {
+            return;
+        }
+
+        $DB->delete_records(self::TABLE, ['courseid' => $courseid]);
+    }
+
+    /**
+     * Convert input to a normalised record ready to persist.
+     *
+     * @param array|\stdClass $data
+     * @return \stdClass
+     */
+    private static function normalise_record($data): \stdClass {
+        if (is_array($data)) {
+            $data = (object)$data;
+        }
+
+        if (!($data instanceof \stdClass) || empty($data->courseid)) {
+            throw new \coding_exception('Missing required field: courseid');
+        }
+
+        $record = new \stdClass();
+        $record->courseid = (int)$data->courseid;
+        $record->active_students = isset($data->active_students) ? (int)$data->active_students : 0;
+        $record->inactive_students = isset($data->inactive_students) ? (int)$data->inactive_students : 0;
+        $record->most_active_userid = isset($data->most_active_userid) ? (int)$data->most_active_userid : 0;
+        $record->most_active_interactions = isset($data->most_active_interactions) ? (int)$data->most_active_interactions : 0;
+
+        if (property_exists($data, 'inactive_userids')) {
+            if (is_array($data->inactive_userids)) {
+                $userids = array_values(array_map('intval', $data->inactive_userids));
+                $record->inactive_userids = json_encode($userids);
+            } else if ($data->inactive_userids === null || $data->inactive_userids === '') {
+                $record->inactive_userids = null;
+            } else {
+                $record->inactive_userids = (string)$data->inactive_userids;
+            }
+        } else {
+            $record->inactive_userids = null;
+        }
+
+        $record->last_calculated = isset($data->last_calculated) ? (int)$data->last_calculated : time();
+
+        return $record;
+    }
+}
+

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="blocks/student_engagement/db" VERSION="2026031000" COMMENT="XMLDB file for block_student_engagement"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="block_student_engagement_cache" COMMENT="Cached engagement metrics by course">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="active_students" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="inactive_students" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="most_active_userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="most_active_interactions" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="inactive_userids" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="last_calculated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="courseid_uix" UNIQUE="true" FIELDS="courseid"/>
+        <INDEX NAME="last_calculated_ix" UNIQUE="false" FIELDS="last_calculated"/>
+      </INDEXES>
+    </TABLE>
+  </TABLES>
+</XMLDB>
+

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade steps for block_student_engagement.
+ *
+ * @package    block_student_engagement
+ * @copyright  2026 Bastian Coquedano
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Execute block_student_engagement upgrade from the given old version.
+ *
+ * @param int $oldversion
+ * @return bool
+ */
+function xmldb_block_student_engagement_upgrade(int $oldversion): bool {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2026031000) {
+        $table = new xmldb_table('block_student_engagement_cache');
+
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('active_students', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('inactive_students', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('most_active_userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('most_active_interactions', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        // Stores a JSON array of inactive user IDs (e.g. [12,34,56]).
+        $table->add_field('inactive_userids', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('last_calculated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Enforce one cache record per course and support ordering/filtering by recency.
+        $courseindex = new xmldb_index('courseid_uix', XMLDB_INDEX_UNIQUE, ['courseid']);
+        if (!$dbman->index_exists($table, $courseindex)) {
+            $dbman->add_index($table, $courseindex);
+        }
+
+        $lastcalcindex = new xmldb_index('last_calculated_ix', XMLDB_INDEX_NOTUNIQUE, ['last_calculated']);
+        if (!$dbman->index_exists($table, $lastcalcindex)) {
+            $dbman->add_index($table, $lastcalcindex);
+        }
+
+        upgrade_block_savepoint(true, 2026031000, 'student_engagement');
+    }
+
+    return true;
+}
+

--- a/lang/en/block_student_engagement.php
+++ b/lang/en/block_student_engagement.php
@@ -27,4 +27,15 @@ $string['student_engagement:addinstance'] = 'Add a new Student Engagement block'
 $string['student_engagement:myaddinstance'] = 'Add a new Student Engagement block to Dashboard';
 $string['student_engagement:view'] = 'View Student Engagement block';
 $string['contentnotready'] = 'Engagement metrics are not available yet.';
+$string['cachenotavailable'] = 'Engagement metrics have not been calculated for this course yet.';
 $string['nopermissions'] = 'You do not have permission to view this block.';
+
+$string['active_days_threshold'] = 'Active days threshold';
+$string['active_days_threshold_desc'] = 'Number of days with recent activity to consider a student active.';
+$string['inactive_days_threshold'] = 'Inactive days threshold';
+$string['inactive_days_threshold_desc'] = 'Number of days without activity to consider a student inactive.';
+
+$string['active_students'] = 'Active students';
+$string['inactive_students'] = 'Inactive students';
+$string['most_active_user'] = 'Most active user';
+$string['last_calculated'] = 'Last calculated';

--- a/lang/es/block_student_engagement.php
+++ b/lang/es/block_student_engagement.php
@@ -27,4 +27,15 @@ $string['student_engagement:addinstance'] = 'Agregar un nuevo bloque de Particip
 $string['student_engagement:myaddinstance'] = 'Agregar un nuevo bloque de Participación estudiantil al tablero';
 $string['student_engagement:view'] = 'Ver bloque de Participación estudiantil';
 $string['contentnotready'] = 'Las métricas de participación aún no están disponibles.';
+$string['cachenotavailable'] = 'Las métricas de participación aún no se han calculado para este curso.';
 $string['nopermissions'] = 'No tienes permisos para ver este bloque.';
+
+$string['active_days_threshold'] = 'Umbral de días activos';
+$string['active_days_threshold_desc'] = 'Número de días con actividad reciente para considerar a un estudiante activo.';
+$string['inactive_days_threshold'] = 'Umbral de días de inactividad';
+$string['inactive_days_threshold_desc'] = 'Número de días sin actividad para considerar a un estudiante inactivo.';
+
+$string['active_students'] = 'Estudiantes activos';
+$string['inactive_students'] = 'Estudiantes inactivos';
+$string['most_active_user'] = 'Usuario más activo';
+$string['last_calculated'] = 'Último cálculo';

--- a/settings.php
+++ b/settings.php
@@ -25,5 +25,19 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($ADMIN->fulltree) {
-    // Bootstrap stage: no configurable settings yet.
+    $settings->add(new admin_setting_configtext(
+        'block_student_engagement/active_days_threshold',
+        get_string('active_days_threshold', 'block_student_engagement'),
+        get_string('active_days_threshold_desc', 'block_student_engagement'),
+        7,
+        PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configtext(
+        'block_student_engagement/inactive_days_threshold',
+        get_string('inactive_days_threshold', 'block_student_engagement'),
+        get_string('inactive_days_threshold_desc', 'block_student_engagement'),
+        14,
+        PARAM_INT
+    ));
 }

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026030900; // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026031000; // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2024100100; // Requires this Moodle version (4.5).
 $plugin->component = 'block_student_engagement';


### PR DESCRIPTION
Implements Issue #2: adds XMLDB cache table (unique courseid + index last_calculated), upgrade step, cache_manager class, admin settings (active/inactive days thresholds), EN/ES strings, and block runtime read from cache.

Notes: calculation from logstore_standard_log is intentionally out of scope for this PR.