### PR TITLE
fix: neutralize XLSX formula injection vectors in export (SE-001)

### DIFF
--- a/classes/output/report_table.php
+++ b/classes/output/report_table.php
@@ -107,15 +107,15 @@ class report_table extends \table_sql {
     public static function format_export_row(\stdClass $row, bool $legacyinactiveview): array {
         if ($legacyinactiveview) {
             return [
-                (string)$row->studentname,
+                self::sanitize_spreadsheet_text((string)$row->studentname),
                 self::format_days_inactive($row),
-                self::format_last_access($row),
+                self::sanitize_spreadsheet_text(self::format_last_access($row)),
             ];
         }
 
         return [
-            (string)$row->studentname,
-            self::format_last_access($row),
+            self::sanitize_spreadsheet_text((string)$row->studentname),
+            self::sanitize_spreadsheet_text(self::format_last_access($row)),
             self::format_days_inactive($row),
             (string)(int)$row->recentevents,
             (string)((int)$row->completedcount . ' / ' . (int)$row->totalactivities . ' (' . (int)$row->completedprogress . '%)'),
@@ -124,9 +124,35 @@ class report_table extends \table_sql {
             self::format_nullable_grade($row->gradegap),
             (string)((int)$row->engagementscore . ' / 100'),
             (string)((int)$row->riskscore . ' / 100'),
-            get_string('risk_level_label_' . (int)$row->risklevel, 'block_student_engagement'),
-            self::format_risk_flags_text($row),
+            self::sanitize_spreadsheet_text(get_string('risk_level_label_' . (int)$row->risklevel, 'block_student_engagement')),
+            self::sanitize_spreadsheet_text(self::format_risk_flags_text($row)),
         ];
+    }
+
+    /**
+     * Neutralize spreadsheet formula prefixes in exported text cells.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function sanitize_spreadsheet_text(string $value): string {
+        $value = (string)$value;
+        if ($value === '') {
+            return $value;
+        }
+
+        // Ignore leading whitespace/control chars when deciding if a cell could be interpreted as a formula.
+        $leadingtrimmed = ltrim($value, " \t\r\n");
+        if ($leadingtrimmed === '') {
+            return $value;
+        }
+
+        $firstchar = \core_text::substr($leadingtrimmed, 0, 1);
+        if (in_array($firstchar, ['=', '+', '-', '@'], true)) {
+            return "'" . $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/report.php
+++ b/report.php
@@ -194,13 +194,23 @@ if ($export === 'excel') {
     );
     $writer->addRow(
         \OpenSpout\Common\Entity\Row::fromValues(
-            $padrow([get_string('export_metadata_course', 'block_student_engagement'), format_string($course->fullname) . ' (#' . $courseid . ')']),
+            $padrow([
+                get_string('export_metadata_course', 'block_student_engagement'),
+                \block_student_engagement\output\report_table::sanitize_spreadsheet_text(
+                    format_string($course->fullname) . ' (#' . $courseid . ')'
+                ),
+            ]),
             $boldcenterstyle
         )
     );
     $writer->addRow(
         \OpenSpout\Common\Entity\Row::fromValues(
-            $padrow([get_string('export_metadata_exported_by', 'block_student_engagement'), fullname($USER) . ' (' . $USER->username . ' #' . $USER->id . ')']),
+            $padrow([
+                get_string('export_metadata_exported_by', 'block_student_engagement'),
+                \block_student_engagement\output\report_table::sanitize_spreadsheet_text(
+                    fullname($USER) . ' (' . $USER->username . ' #' . $USER->id . ')'
+                ),
+            ]),
             $boldcenterstyle
         )
     );


### PR DESCRIPTION
## Summary
- Adds spreadsheet-safe sanitization for exported text cells to prevent formula injection (`=`, `+`, `-`, `@`).
- Applies sanitization to exported report rows (`studentname`, risk labels/flags, last access text).
- Applies sanitization to export metadata fields in `report.php` (course name and exported-by string).

## Why
Implements issue #22 (`[Security][SE-001] Neutralizar Excel Formula Injection en exportación XLSX`).

## Validation
- `docker exec moodle_web php -l /var/www/html/blocks/student_engagement/report.php`
- `docker exec moodle_web php -l /var/www/html/blocks/student_engagement/classes/output/report_table.php`

## Notes
- Scope intentionally limited to export hardening (no behavior changes outside XLSX text sanitization).
- Existing untracked local docs were intentionally excluded from this PR.

Closes #22
