### PR TITLE
fix(reporte): validar autorización de groupid en filtros (SE-002)

### DIFF
--- a/report.php
+++ b/report.php
@@ -42,7 +42,11 @@ require_login($course);
 $context = context_course::instance($courseid);
 require_capability('block/student_engagement:viewreport', $context);
 
-$groups = groups_get_all_groups($courseid) ?: [];
+// Restrict filterable groups to those the current user can legitimately access.
+// Users with accessallgroups can filter any course group; others are limited to their memberships.
+$canaccessallgroups = has_capability('moodle/site:accessallgroups', $context);
+$groupuserid = $canaccessallgroups ? 0 : (int)$USER->id;
+$groups = groups_get_all_groups($courseid, $groupuserid) ?: [];
 
 $filterformurl = new moodle_url('/blocks/student_engagement/report.php', [
     'courseid' => $courseid,


### PR DESCRIPTION
## Resumen
- Restringe los grupos del filtro a los que el usuario actual puede acceder legítimamente.
- Si el usuario tiene `moodle/site:accessallgroups`, puede filtrar cualquier grupo del curso.
- Si no lo tiene, el filtro se limita a sus membresías y `groupid` no autorizado se normaliza a `0`.

## Motivo
Implementa el issue #23 (`[Security][SE-002] Validar autorización de groupid en filtros del reporte`).

## Validación
- `docker exec moodle_web php -l /var/www/html/blocks/student_engagement/report.php`

## Notas
- Cambio acotado a `report.php`, sin modificar SQL ni estructura de UI.

Closes #23
