### PR TITLE
[Security][SE-003] Minimizar metadatos sensibles en exportación de reportes

### DIFF
--- a/report.php
+++ b/report.php
@@ -201,7 +201,7 @@ if ($export === 'excel') {
             $padrow([
                 get_string('export_metadata_course', 'block_student_engagement'),
                 \block_student_engagement\output\report_table::sanitize_spreadsheet_text(
-                    format_string($course->fullname) . ' (#' . $courseid . ')'
+                    format_string($course->fullname)
                 ),
             ]),
             $boldcenterstyle
@@ -212,7 +212,7 @@ if ($export === 'excel') {
             $padrow([
                 get_string('export_metadata_exported_by', 'block_student_engagement'),
                 \block_student_engagement\output\report_table::sanitize_spreadsheet_text(
-                    fullname($USER) . ' (' . $USER->username . ' #' . $USER->id . ')'
+                    fullname($USER)
                 ),
             ]),
             $boldcenterstyle


### PR DESCRIPTION
## Resumen
Se minimizan metadatos sensibles en la exportación XLSX del reporte.

- Se elimina username e ID interno del usuario exportador del campo **Exported by**.
- Se elimina el ID interno de curso del campo **Course**.
- Se conserva trazabilidad mínima: fecha de generación, curso (nombre visible) y exportado por (nombre visible).

## Cambios
- report.php: ajuste de metadata de exportación para excluir identificadores internos.

## Validación
- Diff acotado: 1 archivo, 2 líneas ajustadas.
- Verificada ausencia de username/id en metadata exportada.

## Issue
- [Security][SE-003] Minimizar metadatos sensibles en exportación de reportes