### PR TITLE
[Security][SE-004] Endurecer exportación para evitar degradación por volumen

### DIFF
--- a/lang/en/block_student_engagement.php
+++ b/lang/en/block_student_engagement.php
@@ -42,6 +42,8 @@ $string['inactive_days_threshold'] = 'Inactive days threshold';
 $string['inactive_days_threshold_desc'] = 'Number of days without activity to consider a student inactive.';
 $string['report_event_goal'] = 'Report event goal';
 $string['report_event_goal_desc'] = 'Number of course events required to award the full 30 event points in the engagement report.';
+$string['export_max_rows'] = 'Maximum rows for synchronous export';
+$string['export_max_rows_desc'] = 'Maximum number of rows allowed for direct XLSX export. Requests above this limit are blocked to protect platform performance.';
 $string['risk_enabled'] = 'Enable academic risk calculation';
 $string['risk_enabled_desc'] = 'When enabled, cron calculates per-student academic risk and stores results in cache tables.';
 $string['risk_grade_weight'] = 'Risk weight: grade';
@@ -122,6 +124,7 @@ $string['export_excel'] = 'Export Excel';
 $string['export_metadata_generated_at'] = 'Generated at';
 $string['export_metadata_course'] = 'Course';
 $string['export_metadata_exported_by'] = 'Exported by';
+$string['export_limit_reached'] = 'Export blocked: this report has more rows than the configured limit ({$a}). Please narrow filters and try again.';
 
 $string['risk_level_label_0'] = 'Normal';
 $string['risk_level_label_1'] = 'Observation';

--- a/lang/es/block_student_engagement.php
+++ b/lang/es/block_student_engagement.php
@@ -42,6 +42,8 @@ $string['inactive_days_threshold'] = 'Umbral de días de inactividad';
 $string['inactive_days_threshold_desc'] = 'Número de días sin actividad para considerar a un estudiante inactivo.';
 $string['report_event_goal'] = 'Meta de eventos del reporte';
 $string['report_event_goal_desc'] = 'Número de eventos del curso necesarios para otorgar los 30 puntos completos en el reporte de engagement.';
+$string['export_max_rows'] = 'Maximo de filas para exportacion sincrona';
+$string['export_max_rows_desc'] = 'Numero maximo de filas permitido para exportacion XLSX directa. Las solicitudes que superen este limite se bloquean para proteger el rendimiento de la plataforma.';
 $string['risk_enabled'] = 'Habilitar calculo de riesgo academico';
 $string['risk_enabled_desc'] = 'Cuando esta habilitado, el cron calcula riesgo academico por estudiante y lo guarda en tablas de cache.';
 $string['risk_grade_weight'] = 'Peso de riesgo: nota';
@@ -122,6 +124,7 @@ $string['export_excel'] = 'Exportar Excel';
 $string['export_metadata_generated_at'] = 'Generado el';
 $string['export_metadata_course'] = 'Curso';
 $string['export_metadata_exported_by'] = 'Exportado por';
+$string['export_limit_reached'] = 'Exportacion bloqueada: este reporte tiene mas filas que el limite configurado ({$a}). Aplica filtros mas acotados y vuelve a intentarlo.';
 
 $string['risk_level_label_0'] = 'Normal';
 $string['risk_level_label_1'] = 'Observación';

--- a/report.php
+++ b/report.php
@@ -148,6 +148,20 @@ $studentcount = \block_student_engagement\engagement_report::count_rows($coursei
 
 if ($export === 'excel') {
     require_sesskey();
+    $exportmaxrows = (int)get_config('block_student_engagement', 'export_max_rows');
+    if ($exportmaxrows <= 0) {
+        $exportmaxrows = 5000;
+    }
+
+    // Guardrail: avoid synchronous exports that can overload memory/CPU on very large courses.
+    if ($studentcount > $exportmaxrows) {
+        redirect(
+            $url,
+            get_string('export_limit_reached', 'block_student_engagement', $exportmaxrows),
+            null,
+            \core\output\notification::NOTIFY_ERROR
+        );
+    }
 
     // Export uses the same sort defaults as the current view so on-screen and downloaded data remain consistent.
     $defaultsort = ($legacyinactive) ? 'daysinactive' : 'risklevel';

--- a/settings.php
+++ b/settings.php
@@ -50,6 +50,14 @@ if ($ADMIN->fulltree) {
         PARAM_INT
     ));
 
+    $settings->add(new admin_setting_configtext(
+        'block_student_engagement/export_max_rows',
+        get_string('export_max_rows', 'block_student_engagement'),
+        get_string('export_max_rows_desc', 'block_student_engagement'),
+        5000,
+        PARAM_INT
+    ));
+
     $settings->add(new admin_setting_configcheckbox(
         'block_student_engagement/risk_enabled',
         get_string('risk_enabled', 'block_student_engagement'),


### PR DESCRIPTION
## Resumen
Se agrega un guardrail de volumen para la exportación XLSX síncrona, evitando degradación de memoria/CPU en cursos masivos.

## Cambios
- Se agrega setting administrable `export_max_rows` en `settings.php` (default: 5000).
- En `report.php`, antes de construir el XLSX, se valida el total de filas (`count_rows`) contra el límite configurado.
- Si el límite se excede, la exportación se bloquea con redirección controlada y notificación de error clara para el usuario.
- Se agregan strings EN/ES para setting y mensaje de límite excedido.

## Criterios de aceptación
- [x] Se aplica límite configurable para export síncrono.
- [x] Export normal no se rompe para cursos pequeños.
- [x] Usuario recibe mensaje claro al exceder umbral.

## Validación
- Revisión de diff: 4 archivos, cambios acotados al flujo de export/settings/strings.
- Verificación de wiring de strings y lectura de configuración (`export_max_rows`).
- Nota: no fue posible ejecutar lint PHP local porque `php` no está disponible en este entorno.

## Fuera de alcance
- Exportación asíncrona por tarea.
- Métricas de tiempo/volumen adicionales.