### PR TITLE
[Security][SE-006] Hardening SQL: placeholders obligatorios y auditoría anti-SQLi

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ Retention policy:
 
 This plugin does not currently implement an automatic time-based purge window; retention is managed through Moodle privacy workflows and course lifecycle operations.
 
+## SQL hardening policy
+
+Secure-by-default SQL rules for this plugin:
+
+- Every variable value in SQL must use named placeholders (`:param`) with `$DB` methods.
+- User input must be validated first (`required_param` / `optional_param` + strict whitelist/range checks), then mapped to placeholders.
+- Dynamic `ORDER BY` is allowed only through closed whitelists (`engagement_report::get_sort_sql`), never by concatenating raw input.
+- `IN (...)` clauses must be built with `$DB->get_in_or_equal(...)`.
+
+Anti-SQLi regression coverage:
+
+- `tests/engagement_report_security_test.php` validates sort whitelist behavior and malicious filter payload handling.
+
 ## Current status
 
 Implemented in v1:

--- a/classes/engagement_report.php
+++ b/classes/engagement_report.php
@@ -60,7 +60,8 @@ class engagement_report {
      * Return report rows for a course.
      *
      * @param int $courseid
-     * @param string $sort
+     * @param string $sortcolumn
+     * @param string $sortdirection
      * @param int $limitfrom
      * @param int $limitnum
      * @param string $viewmode
@@ -69,7 +70,8 @@ class engagement_report {
      */
     public static function get_rows(
         int $courseid,
-        string $sort,
+        string $sortcolumn = 'risklevel',
+        string $sortdirection = 'DESC',
         int $limitfrom = 0,
         int $limitnum = 0,
         string $viewmode = 'all',
@@ -81,6 +83,7 @@ class engagement_report {
         $parts = self::build_shared_sql_parts($courseid, $filterdata);
         $totalactivities = self::get_total_completable_activities($courseid);
         $eventgoal = self::get_event_goal();
+        $ordersql = self::get_sort_sql($sortcolumn, $sortdirection, $viewmode);
 
         $scoreexpression = self::get_score_sql();
         $sql = "SELECT students.userid,
@@ -113,7 +116,7 @@ class engagement_report {
                        {$scoreexpression} AS engagementscore
                   {$parts['from']}
                  {$parts['where']}
-              ORDER BY {$sort}";
+              ORDER BY {$ordersql}";
 
         $params = $parts['params'];
         $params['eventgoalcompare'] = max(1, $eventgoal);

--- a/classes/output/report_table.php
+++ b/classes/output/report_table.php
@@ -247,10 +247,10 @@ class report_table extends \table_sql {
             $direction = strtoupper($parts[1] ?? 'ASC');
         }
 
-        $ordersql = \block_student_engagement\engagement_report::get_sort_sql($sortcolumn, $direction, $this->viewmode);
         $this->rawdata = \block_student_engagement\engagement_report::get_rows(
             $this->courseid,
-            $ordersql,
+            $sortcolumn,
+            $direction,
             $this->get_page_start(),
             $this->get_page_size(),
             $this->viewmode,

--- a/report.php
+++ b/report.php
@@ -166,10 +166,10 @@ if ($export === 'excel') {
     // Export uses the same sort defaults as the current view so on-screen and downloaded data remain consistent.
     $defaultsort = ($legacyinactive) ? 'daysinactive' : 'risklevel';
     $defaultdir = 'DESC';
-    $ordersql = \block_student_engagement\engagement_report::get_sort_sql($defaultsort, $defaultdir, $effectiveview);
     $rows = \block_student_engagement\engagement_report::get_rows(
         $courseid,
-        $ordersql,
+        $defaultsort,
+        $defaultdir,
         0,
         0,
         $effectiveview,

--- a/tests/engagement_report_security_test.php
+++ b/tests/engagement_report_security_test.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Security hardening tests for engagement report SQL handling.
+ *
+ * @package    block_student_engagement
+ * @copyright  2026 Bastian Coquedano
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_student_engagement;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * SQL hardening regression tests.
+ */
+final class engagement_report_security_test extends \advanced_testcase {
+
+    /**
+     * Unknown sort tokens must fall back to whitelist defaults.
+     *
+     * @return void
+     */
+    public function test_get_sort_sql_rejects_injected_sort_column(): void {
+        $sql = engagement_report::get_sort_sql("risklevel DESC, (SELECT 1)", 'DESC', 'all');
+        $this->assertSame(
+            'risklevel DESC, riskscore DESC, daysinactivevalue DESC, student ASC, studentfirstname ASC',
+            $sql
+        );
+    }
+
+    /**
+     * Direction accepts only ASC|DESC and defaults safely for injected payloads.
+     *
+     * @return void
+     */
+    public function test_get_sort_sql_rejects_injected_direction(): void {
+        $sql = engagement_report::get_sort_sql('student', 'DESC; DROP TABLE user; --', 'all');
+        $this->assertSame('student ASC, studentfirstname ASC', $sql);
+    }
+
+    /**
+     * Row retrieval should remain stable with malicious filter payloads.
+     *
+     * @return void
+     */
+    public function test_get_rows_with_malicious_filter_payloads_is_safe(): void {
+        $this->resetAfterTest(true);
+
+        $course = $this->getDataGenerator()->create_course();
+        $rows = engagement_report::get_rows(
+            (int)$course->id,
+            "risklevel DESC, (SELECT 1)",
+            "DESC; DROP TABLE mdl_user; --",
+            0,
+            10,
+            'all',
+            [
+                'risklevel' => "' OR 1=1 --",
+                'groupid' => "1 OR 1=1",
+                'status' => "inactive' OR '1'='1",
+                'atrisk' => false,
+            ]
+        );
+
+        $this->assertIsArray($rows);
+    }
+}
+


### PR DESCRIPTION
## Resumen
Se endurece el flujo SQL del reporte para eliminar superficies de inyección en `ORDER BY` y se agregan pruebas de regresión anti-SQLi para sort/filtros.

## Cambios
- `engagement_report::get_rows(...)` ahora recibe `sortcolumn` + `sortdirection` y aplica whitelist interna vía `get_sort_sql(...)`.
- Se mantiene uso de placeholders para valores variables SQL (`:param`) sin concatenar input de usuario.
- Se actualizan `report.php` y `report_table.php` para enviar columna/dirección, no fragmentos SQL.
- Se agrega prueba de seguridad: `tests/engagement_report_security_test.php`.
- Se documenta política SQL secure-by-default en README.

## Criterios de aceptación
- [x] No hay concatenación directa de input de usuario en SQL ejecutado por `$DB`.
- [x] Sort y dirección pasan por whitelist cerrada.
- [x] Existen pruebas de regresión anti-SQLi para sort/filtros principales.
- [x] Regla de desarrollo seguro SQL documentada.

## Validación
- `php -l` OK en archivos modificados.
- Revisión manual de diff para confirmar placeholders y whitelist de sort.
- PHPUnit no disponible/no inicializado en este entorno de contenedor.