### PR TITLE
Optimizar filtros SQL de engagement

### DIFF
--- a/classes/engagement_report.php
+++ b/classes/engagement_report.php
@@ -95,10 +95,10 @@ class engagement_report {
                        u.alternatename,
                        u.lastname AS student,
                        u.firstname AS studentfirstname,
-                       COALESCE(events.eventcount, 0) AS eventcount,
-                       COALESCE(risk.recent_events, COALESCE(events.eventcount, 0)) AS recentevents,
+                       COALESCE(logsummary.eventcount, 0) AS eventcount,
+                       COALESCE(risk.recent_events, COALESCE(logsummary.eventcount, 0)) AS recentevents,
                        COALESCE(completed.completedcount, 0) AS completedcount,
-                       COALESCE(lastaccess.lastcourseaccess, 0) AS lastcourseaccess,
+                       COALESCE(logsummary.lastcourseaccess, 0) AS lastcourseaccess,
                        risk.current_grade AS currentgrade,
                        risk.pass_grade AS passgrade,
                        risk.grade_gap AS gradegap,
@@ -109,8 +109,8 @@ class engagement_report {
                        COALESCE(
                            risk.days_inactive,
                            CASE
-                               WHEN COALESCE(lastaccess.lastcourseaccess, 0) = 0 THEN NULL
-                               ELSE FLOOR((:currenttimestamp - lastaccess.lastcourseaccess) / :secondsinday)
+                               WHEN COALESCE(logsummary.lastcourseaccess, 0) = 0 THEN NULL
+                               ELSE FLOOR((:currenttimestamp - logsummary.lastcourseaccess) / :secondsinday)
                            END
                        ) AS daysinactivevalue,
                        {$scoreexpression} AS engagementscore
@@ -186,12 +186,14 @@ class engagement_report {
                    ) students
               JOIN {user} u ON u.id = students.userid
          LEFT JOIN (
-                    SELECT l.userid, COUNT(1) AS eventcount
+                    SELECT l.userid,
+                           COUNT(1) AS eventcount,
+                           MAX(l.timecreated) AS lastcourseaccess
                       FROM {logstore_standard_log} l
-                     WHERE l.courseid = :eventcourseid
+                     WHERE l.courseid = :logcourseid
                        AND l.userid > 0
                   GROUP BY l.userid
-                   ) events ON events.userid = students.userid
+                   ) logsummary ON logsummary.userid = students.userid
          LEFT JOIN (
                     SELECT c.userid, COUNT(DISTINCT c.coursemoduleid) AS completedcount
                       FROM {course_modules_completion} c
@@ -201,13 +203,6 @@ class engagement_report {
                        AND c.completionstate <> 0
                   GROUP BY c.userid
                    ) completed ON completed.userid = students.userid
-         LEFT JOIN (
-                    SELECT l.userid, MAX(l.timecreated) AS lastcourseaccess
-                      FROM {logstore_standard_log} l
-                     WHERE l.courseid = :lastaccesscourseid
-                       AND l.userid > 0
-                  GROUP BY l.userid
-                   ) lastaccess ON lastaccess.userid = students.userid
          LEFT JOIN {block_student_engagement_risk} risk
                 ON risk.courseid = :riskcourseid
                AND risk.userid = students.userid";
@@ -216,9 +211,8 @@ class engagement_report {
         $params = [
             'contextcourse' => CONTEXT_COURSE,
             'maincourseid' => $courseid,
-            'eventcourseid' => $courseid,
+            'logcourseid' => $courseid,
             'completioncourseid' => $courseid,
-            'lastaccesscourseid' => $courseid,
             'riskcourseid' => $courseid,
             'studentshortname' => self::STUDENT_ROLE_SHORTNAME,
         ];
@@ -234,30 +228,42 @@ class engagement_report {
         }
 
         if (!empty($filters['atrisk'])) {
-            $where .= " AND COALESCE(risk.risk_level, 0) >= :risklevelmin";
+            $where .= " AND risk.risk_level >= :risklevelmin";
             $params['risklevelmin'] = 2;
         } else if ($filters['risklevel'] !== null) {
-            $where .= " AND COALESCE(risk.risk_level, 0) = :risklevel";
             $params['risklevel'] = (int)$filters['risklevel'];
+            if ((int)$filters['risklevel'] === 0) {
+                $where .= " AND (risk.risk_level = :risklevel OR risk.risk_level IS NULL)";
+            } else {
+                $where .= " AND risk.risk_level = :risklevel";
+            }
         }
 
         if ($filters['status'] === 'inactive' || $filters['legacyinactive']) {
             $where .= " AND (
-                COALESCE(lastaccess.lastcourseaccess, 0) = 0
-                OR COALESCE(
-                    risk.days_inactive,
-                    FLOOR((:currenttimeinactive - lastaccess.lastcourseaccess) / :daysecsinactive)
-                ) >= :inactivedaysthreshold
+                logsummary.lastcourseaccess IS NULL
+                OR logsummary.lastcourseaccess = 0
+                OR risk.days_inactive >= :inactivedaysthreshold
+                OR (
+                    risk.days_inactive IS NULL
+                    AND logsummary.lastcourseaccess > 0
+                    AND FLOOR((:currenttimeinactive - logsummary.lastcourseaccess) / :daysecsinactive) >= :inactivedaysthreshold
+                )
             )";
             $params['currenttimeinactive'] = (int)$filters['currenttime'];
             $params['daysecsinactive'] = DAYSECS;
             $params['inactivedaysthreshold'] = (int)$filters['inactivedaysthreshold'];
         } else if ($filters['status'] === 'active') {
-            $where .= " AND COALESCE(lastaccess.lastcourseaccess, 0) > 0
-                        AND COALESCE(
-                            risk.days_inactive,
-                            FLOOR((:currenttimeactive - lastaccess.lastcourseaccess) / :daysecsactive)
-                        ) < :inactivedaysthreshold";
+            $where .= " AND logsummary.lastcourseaccess > 0
+                        AND (
+                            risk.days_inactive < :inactivedaysthreshold
+                            OR (
+                                risk.days_inactive IS NULL
+                                AND FLOOR(
+                                    (:currenttimeactive - logsummary.lastcourseaccess) / :daysecsactive
+                                ) < :inactivedaysthreshold
+                            )
+                        )";
             $params['currenttimeactive'] = (int)$filters['currenttime'];
             $params['daysecsactive'] = DAYSECS;
             $params['inactivedaysthreshold'] = (int)$filters['inactivedaysthreshold'];
@@ -367,9 +373,9 @@ class engagement_report {
                         ELSE 0
                     END) +
                     (CASE
-                        WHEN COALESCE(events.eventcount, 0) >= :eventgoalcompare
+                        WHEN COALESCE(logsummary.eventcount, 0) >= :eventgoalcompare
                         THEN 30
-                        ELSE (COALESCE(events.eventcount, 0) * 30.0 / :eventgoalscale)
+                        ELSE (COALESCE(logsummary.eventcount, 0) * 30.0 / :eventgoalscale)
                     END),
                 0)";
     }

--- a/tests/engagement_report_security_test.php
+++ b/tests/engagement_report_security_test.php
@@ -32,6 +32,20 @@ defined('MOODLE_INTERNAL') || die();
 final class engagement_report_security_test extends \advanced_testcase {
 
     /**
+     * Invoke private static method on engagement_report via reflection.
+     *
+     * @param string $method
+     * @param mixed ...$args
+     * @return mixed
+     */
+    private function invoke_private_static(string $method, ...$args) {
+        $refclass = new \ReflectionClass(engagement_report::class);
+        $refmethod = $refclass->getMethod($method);
+        $refmethod->setAccessible(true);
+        return $refmethod->invoke(null, ...$args);
+    }
+
+    /**
      * Unknown sort tokens must fall back to whitelist defaults.
      *
      * @return void
@@ -80,5 +94,122 @@ final class engagement_report_security_test extends \advanced_testcase {
 
         $this->assertIsArray($rows);
     }
-}
 
+    /**
+     * Risk-level predicates should avoid COALESCE over indexed columns.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_uses_sargable_risk_level_predicates(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', ['atrisk' => true]);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $this->assertStringNotContainsString('COALESCE(risk.risk_level, 0)', $parts['where']);
+        $this->assertStringContainsString('risk.risk_level >= :risklevelmin', $parts['where']);
+    }
+
+    /**
+     * Risk level zero filter must include rows without risk cache.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_risklevel_zero_keeps_null_semantics(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', ['risklevel' => '0']);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $this->assertStringContainsString('(risk.risk_level = :risklevel OR risk.risk_level IS NULL)', $parts['where']);
+        $this->assertSame(0, $parts['params']['risklevel']);
+    }
+
+    /**
+     * Non-zero risk-level filters should use direct predicates.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_nonzero_risklevels_use_direct_predicates(): void {
+        foreach ([1, 2, 3] as $risklevel) {
+            $filters = $this->invoke_private_static('normalise_filters', 'all', ['risklevel' => (string)$risklevel]);
+            $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+            $this->assertStringContainsString('risk.risk_level = :risklevel', $parts['where']);
+            $this->assertStringNotContainsString('risk.risk_level IS NULL', $parts['where']);
+            $this->assertStringNotContainsString('COALESCE(risk.risk_level, 0)', $parts['where']);
+            $this->assertSame($risklevel, $parts['params']['risklevel']);
+        }
+    }
+
+    /**
+     * Active status should use cached inactivity before calculated fallback.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_active_status_limits_floor_to_uncached_fallback(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', ['status' => 'active']);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $this->assertStringContainsString('logsummary.lastcourseaccess > 0', $parts['where']);
+        $this->assertStringContainsString('risk.days_inactive < :inactivedaysthreshold', $parts['where']);
+        $this->assertStringContainsString('risk.days_inactive IS NULL', $parts['where']);
+        $this->assertStringContainsString('FLOOR(', $parts['where']);
+        $this->assertStringContainsString(':currenttimeactive - logsummary.lastcourseaccess', $parts['where']);
+        $this->assertStringContainsString('/ :daysecsactive', $parts['where']);
+        $this->assertStringNotContainsString('COALESCE(', $parts['where']);
+    }
+
+    /**
+     * Inactive status should use cached inactivity before calculated fallback.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_inactive_status_limits_floor_to_uncached_fallback(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', ['status' => 'inactive']);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $this->assertStringContainsString('logsummary.lastcourseaccess IS NULL', $parts['where']);
+        $this->assertStringContainsString('logsummary.lastcourseaccess = 0', $parts['where']);
+        $this->assertStringContainsString('risk.days_inactive >= :inactivedaysthreshold', $parts['where']);
+        $this->assertStringContainsString('risk.days_inactive IS NULL', $parts['where']);
+        $this->assertStringContainsString(
+            'FLOOR((:currenttimeinactive - logsummary.lastcourseaccess) / :daysecsinactive)',
+            $parts['where']
+        );
+        $this->assertStringNotContainsString('COALESCE(', $parts['where']);
+    }
+
+    /**
+     * Group filters should compose with risk and status predicates.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_group_filter_composes_with_risk_and_status(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', [
+            'groupid' => '42',
+            'risklevel' => '2',
+            'status' => 'inactive',
+        ]);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $this->assertStringContainsString('FROM {groups_members} gm', $parts['where']);
+        $this->assertStringContainsString('gm.userid = students.userid', $parts['where']);
+        $this->assertStringContainsString('gm.groupid = :groupid', $parts['where']);
+        $this->assertStringContainsString('risk.risk_level = :risklevel', $parts['where']);
+        $this->assertStringContainsString('risk.days_inactive >= :inactivedaysthreshold', $parts['where']);
+        $this->assertSame(42, $parts['params']['groupid']);
+        $this->assertSame(2, $parts['params']['risklevel']);
+    }
+
+    /**
+     * Log table should be scanned only once in shared SQL parts.
+     *
+     * @return void
+     */
+    public function test_build_shared_sql_parts_queries_logstore_only_once(): void {
+        $filters = $this->invoke_private_static('normalise_filters', 'all', []);
+        $parts = $this->invoke_private_static('build_shared_sql_parts', 123, $filters);
+
+        $occurrences = substr_count($parts['from'], '{logstore_standard_log}');
+        $this->assertSame(1, $occurrences);
+        $this->assertStringContainsString('COUNT(1) AS eventcount', $parts['from']);
+        $this->assertStringContainsString('MAX(l.timecreated) AS lastcourseaccess', $parts['from']);
+    }
+}


### PR DESCRIPTION
## Resumen
- Consolida el acceso a logstore en un unico subquery `logsummary`.
- Reescribe filtros de riesgo para evitar `COALESCE(risk.risk_level, 0)` en `WHERE`.
- Prioriza `risk.days_inactive` en filtros activo/inactivo y deja `FLOOR(...)` solo como fallback sin cache.
- Amplia pruebas de SQL generado para riesgo, estado, grupo y scan unico de logstore.

## Validacion
- `docker exec moodle_web php -l /var/www/html/blocks/student_engagement/classes/engagement_report.php`
- `docker exec moodle_web php -l /var/www/html/blocks/student_engagement/tests/engagement_report_security_test.php`
- `git diff --check`

No se ejecuto PHPUnit completo porque `phpunit` no esta disponible en `PATH` ni existe `/var/www/html/vendor/bin/phpunit` en el contenedor.

Closes #39
