### PR TITLE
feat(engagement): agregar cache incremental de logstore

### DIFF
--- a/classes/cache_manager.php
+++ b/classes/cache_manager.php
@@ -44,7 +44,8 @@ class cache_manager {
      * Expected keys/props (minimum): courseid.
      * Optional: active_students, inactive_students, most_active_userid,
      * most_active_interactions, inactive_userids (array|string), last_calculated,
-     * at_risk_count, critical_risk_count, average_completion_percent, risk_last_calculated.
+     * at_risk_count, critical_risk_count, average_completion_percent,
+     * risk_last_calculated, last_log_id, last_log_timecreated.
      *
      * @param array|\stdClass $data
      * @return int The record id (inserted or existing).
@@ -139,6 +140,8 @@ class cache_manager {
         $record->critical_risk_count = isset($data->critical_risk_count) ? (int)$data->critical_risk_count : 0;
         $record->average_completion_percent = isset($data->average_completion_percent) ? (int)$data->average_completion_percent : 0;
         $record->risk_last_calculated = isset($data->risk_last_calculated) ? (int)$data->risk_last_calculated : 0;
+        $record->last_log_id = isset($data->last_log_id) ? (int)$data->last_log_id : 0;
+        $record->last_log_timecreated = isset($data->last_log_timecreated) ? (int)$data->last_log_timecreated : 0;
 
         if (property_exists($data, 'inactive_userids')) {
             if (is_array($data->inactive_userids)) {

--- a/classes/engagement_analyser.php
+++ b/classes/engagement_analyser.php
@@ -19,7 +19,7 @@
  * @Author Bastian Coquedano
  *
  * This class is responsible for calculating engagement metrics using Moodle
- * internal tables (especially logstore_standard_log). It is intentionally
+ * internal tables and the plugin's incremental log aggregates. It is intentionally
  * UI-agnostic so it can be reused by scheduled tasks and by the block.
  *
  * Important: keep queries parameterised and apply early filters to make
@@ -38,9 +38,6 @@ defined('MOODLE_INTERNAL') || die();
  * Domain service for engagement calculations.
  */
 class engagement_analyser {
-
-    /** @var string Event name to exclude from interaction counts (noise). */
-    private const EVENT_COURSE_VIEWED = '\\core\\event\\course_viewed';
 
     /** @var string The shortname used to identify the student role. */
     private const STUDENT_ROLE_SHORTNAME = 'student';
@@ -78,7 +75,7 @@ class engagement_analyser {
     /**
      * Get user IDs of students with activity in the last N days.
      *
-     * Activity is based on logstore_standard_log events (excluding course_viewed).
+     * Activity is based on incrementally aggregated logstore events.
      *
      * @param int $courseid
      * @param int|null $days If null, uses active_days_threshold setting.
@@ -95,26 +92,22 @@ class engagement_analyser {
         $days = $days ?? self::active_days_threshold();
         $since = self::since_days($days);
 
-        // Join against role assignments in the course context to avoid large IN() lists
-        // and to ensure we only count students.
-        $sql = "SELECT DISTINCT l.userid
-                  FROM {logstore_standard_log} l
+        $sql = "SELECT DISTINCT la.userid
+                  FROM {" . logstore_aggregator::TABLE . "} la
                   JOIN {context} ctx ON ctx.contextlevel = :contextcourse
                                    AND ctx.instanceid = :ctxcourseid
                   JOIN {role_assignments} ra ON ra.contextid = ctx.id
-                                            AND ra.userid = l.userid
+                                            AND ra.userid = la.userid
                   JOIN {role} r ON r.id = ra.roleid
-                 WHERE l.courseid = :courseid
-                   AND l.userid > 0
-                   AND l.timecreated >= :since
-                   AND l.eventname <> :courseviewed
+                 WHERE la.courseid = :courseid
+                   AND la.userid > 0
+                   AND la.timecreated >= :since
                    AND r.shortname = :studentshortname";
         $params = [
             'contextcourse' => CONTEXT_COURSE,
             'ctxcourseid' => $courseid,
             'courseid' => $courseid,
             'since' => $since,
-            'courseviewed' => self::EVENT_COURSE_VIEWED,
             'studentshortname' => self::STUDENT_ROLE_SHORTNAME,
         ];
 
@@ -168,26 +161,24 @@ class engagement_analyser {
         $days = $days ?? self::active_days_threshold();
         $since = self::since_days($days);
 
-        $sql = "SELECT l.userid, COUNT(1) AS interactions
-                  FROM {logstore_standard_log} l
+        $sql = "SELECT la.userid, SUM(la.event_count) AS interactions
+                  FROM {" . logstore_aggregator::TABLE . "} la
                   JOIN {context} ctx ON ctx.contextlevel = :contextcourse
                                    AND ctx.instanceid = :ctxcourseid
                   JOIN {role_assignments} ra ON ra.contextid = ctx.id
-                                            AND ra.userid = l.userid
+                                            AND ra.userid = la.userid
                   JOIN {role} r ON r.id = ra.roleid
-                 WHERE l.courseid = :courseid
-                   AND l.userid > 0
-                   AND l.timecreated >= :since
-                   AND l.eventname <> :courseviewed
+                 WHERE la.courseid = :courseid
+                   AND la.userid > 0
+                   AND la.timecreated >= :since
                    AND r.shortname = :studentshortname
-              GROUP BY l.userid
+              GROUP BY la.userid
               ORDER BY interactions DESC";
         $params = [
             'contextcourse' => CONTEXT_COURSE,
             'ctxcourseid' => $courseid,
             'courseid' => $courseid,
             'since' => $since,
-            'courseviewed' => self::EVENT_COURSE_VIEWED,
             'studentshortname' => self::STUDENT_ROLE_SHORTNAME,
         ];
 
@@ -225,18 +216,16 @@ class engagement_analyser {
         $days = $days ?? self::inactive_days_threshold();
         $since = self::since_days($days);
 
-        $eventssql = "SELECT COUNT(1)
-                        FROM {logstore_standard_log} l
-                       WHERE l.courseid = :courseid
-                         AND l.userid = :userid
-                         AND l.userid > 0
-                         AND l.timecreated >= :since
-                         AND l.eventname <> :courseviewed";
+        $eventssql = "SELECT COALESCE(SUM(la.event_count), 0)
+                        FROM {" . logstore_aggregator::TABLE . "} la
+                       WHERE la.courseid = :courseid
+                         AND la.userid = :userid
+                         AND la.userid > 0
+                         AND la.timecreated >= :since";
         $eventsparams = [
             'courseid' => $courseid,
             'userid' => $userid,
             'since' => $since,
-            'courseviewed' => self::EVENT_COURSE_VIEWED,
         ];
         $events = (int)$DB->get_field_sql($eventssql, $eventsparams);
 

--- a/classes/local/risk_analyser.php
+++ b/classes/local/risk_analyser.php
@@ -34,9 +34,6 @@ class risk_analyser {
     /** @var string */
     private const RISK_TABLE = 'block_student_engagement_risk';
 
-    /** @var string */
-    private const EVENT_COURSE_VIEWED = '\\core\\event\\course_viewed';
-
     /** @var int */
     private const LEVEL_NORMAL = 0;
     /** @var int */
@@ -104,6 +101,7 @@ class risk_analyser {
                 'pass_grade' => $passgrade,
                 'completion_percent' => $completionpercent,
                 'days_inactive' => $daysinactive,
+                'last_activity_timecreated' => (int)($lastactivityts ?? 0),
                 'recent_events' => $recenteventcount,
                 'engagement_score' => $engagementscore,
                 'course_progress_percent' => $courseprogress,
@@ -140,6 +138,7 @@ class risk_analyser {
 
         $completionpercent = max(0, min(100, (int)($dataset['completion_percent'] ?? 50)));
         $daysinactive = max(0, (int)($dataset['days_inactive'] ?? 0));
+        $lastactivity = max(0, (int)($dataset['last_activity_timecreated'] ?? 0));
         $recentevents = max(0, (int)($dataset['recent_events'] ?? 0));
         $attpercent = self::to_nullable_float($dataset['attendance_percent'] ?? null);
         $engagementscore = max(0, (int)($dataset['engagement_score'] ?? 0));
@@ -175,6 +174,7 @@ class risk_analyser {
             'grade_gap' => $gradegap,
             'completion_percent' => $completionpercent,
             'days_inactive' => $daysinactive,
+            'last_activity_timecreated' => $lastactivity,
             'recent_events' => $recentevents,
             'attendance_percent' => $attpercent,
             'engagement_score' => $engagementscore,
@@ -217,6 +217,7 @@ class risk_analyser {
                 'grade_gap' => $row['grade_gap'],
                 'completion_percent' => (int)$row['completion_percent'],
                 'days_inactive' => (int)$row['days_inactive'],
+                'last_activity_timecreated' => (int)($row['last_activity_timecreated'] ?? 0),
                 'recent_events' => (int)$row['recent_events'],
                 'attendance_percent' => $row['attendance_percent'],
                 'engagement_score' => (int)$row['engagement_score'],
@@ -476,17 +477,15 @@ class risk_analyser {
         global $DB;
 
         $since = max(0, time() - (max(0, $days) * DAYSECS));
-        $sql = "SELECT l.userid, COUNT(1) AS eventcount
-                  FROM {logstore_standard_log} l
-                 WHERE l.courseid = :courseid
-                   AND l.userid > 0
-                   AND l.timecreated >= :since
-                   AND l.eventname <> :courseviewed
-              GROUP BY l.userid";
+        $sql = "SELECT la.userid, SUM(la.event_count) AS eventcount
+                  FROM {" . \block_student_engagement\logstore_aggregator::TABLE . "} la
+                 WHERE la.courseid = :courseid
+                   AND la.userid > 0
+                   AND la.timecreated >= :since
+              GROUP BY la.userid";
         $rows = $DB->get_records_sql($sql, [
             'courseid' => $courseid,
             'since' => $since,
-            'courseviewed' => self::EVENT_COURSE_VIEWED,
         ]);
 
         $map = [];
@@ -504,17 +503,13 @@ class risk_analyser {
     private static function get_last_activity_timestamps(int $courseid): array {
         global $DB;
 
-        $sql = "SELECT l.userid, MAX(l.timecreated) AS lastactivity
-                  FROM {logstore_standard_log} l
-                 WHERE l.courseid = :courseid
-                   AND l.userid > 0
-                   AND l.eventname <> :courseviewed
-              GROUP BY l.userid";
+        $sql = "SELECT la.userid, MAX(la.timecreated) AS lastactivity
+                  FROM {" . \block_student_engagement\logstore_aggregator::TABLE . "} la
+                 WHERE la.courseid = :courseid
+                   AND la.userid > 0
+              GROUP BY la.userid";
 
-        $rows = $DB->get_records_sql($sql, [
-            'courseid' => $courseid,
-            'courseviewed' => self::EVENT_COURSE_VIEWED,
-        ]);
+        $rows = $DB->get_records_sql($sql, ['courseid' => $courseid]);
 
         $map = [];
         foreach ($rows as $row) {

--- a/classes/logstore_aggregator.php
+++ b/classes/logstore_aggregator.php
@@ -1,0 +1,156 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Incremental logstore aggregation service.
+ *
+ * @package    block_student_engagement
+ * @copyright  2026 Bastian Coquedano
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_student_engagement;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Aggregates standard log events so report caches can read compact local data.
+ */
+class logstore_aggregator {
+
+    /** @var string Aggregation table name. */
+    public const TABLE = 'block_student_engagement_log_agg';
+
+    /** @var string Event name to exclude from interaction counts. */
+    private const EVENT_COURSE_VIEWED = '\\core\\event\\course_viewed';
+
+    /**
+     * Synchronise new standard log rows into the aggregate table.
+     *
+     * @param int $courseid
+     * @param int $lastlogid Confirmed cursor from the course cache.
+     * @return \stdClass Cursor payload with last_log_id, last_log_timecreated and processed_events.
+     */
+    public static function sync_course(int $courseid, int $lastlogid = 0): \stdClass {
+        global $DB;
+
+        $result = (object)[
+            'last_log_id' => max(0, $lastlogid),
+            'last_log_timecreated' => 0,
+            'processed_events' => 0,
+        ];
+
+        if ($courseid <= 0) {
+            return $result;
+        }
+
+        $sql = "SELECT l.id, l.userid, l.timecreated
+                  FROM {logstore_standard_log} l
+                 WHERE l.courseid = :courseid
+                   AND l.id > :lastlogid
+                   AND l.userid > 0
+                   AND l.eventname <> :courseviewed
+              ORDER BY l.id ASC";
+        $params = [
+            'courseid' => $courseid,
+            'lastlogid' => max(0, $lastlogid),
+            'courseviewed' => self::EVENT_COURSE_VIEWED,
+        ];
+
+        $recordset = $DB->get_recordset_sql($sql, $params);
+        $aggregates = [];
+        foreach ($recordset as $log) {
+            $logid = (int)$log->id;
+            $userid = (int)$log->userid;
+            $timecreated = (int)$log->timecreated;
+            $key = $userid . ':' . $timecreated;
+
+            if (!isset($aggregates[$key])) {
+                $existing = $DB->get_record(self::TABLE, [
+                    'courseid' => $courseid,
+                    'userid' => $userid,
+                    'timecreated' => $timecreated,
+                ], 'id,event_count,last_log_id', IGNORE_MISSING);
+
+                $aggregates[$key] = [
+                    'id' => $existing ? (int)$existing->id : 0,
+                    'courseid' => $courseid,
+                    'userid' => $userid,
+                    'timecreated' => $timecreated,
+                    'event_count' => $existing ? (int)$existing->event_count : 0,
+                    'last_log_id' => $existing ? (int)$existing->last_log_id : 0,
+                    'new_events' => 0,
+                ];
+            }
+
+            if ($logid <= $aggregates[$key]['last_log_id']) {
+                $result->last_log_id = max((int)$result->last_log_id, $logid);
+                $result->last_log_timecreated = max((int)$result->last_log_timecreated, $timecreated);
+                continue;
+            }
+
+            $aggregates[$key]['event_count']++;
+            $aggregates[$key]['new_events']++;
+            $aggregates[$key]['last_log_id'] = $logid;
+            $result->processed_events++;
+            $result->last_log_id = max((int)$result->last_log_id, $logid);
+            $result->last_log_timecreated = max((int)$result->last_log_timecreated, $timecreated);
+        }
+        $recordset->close();
+
+        foreach ($aggregates as $aggregate) {
+            if ($aggregate['new_events'] <= 0) {
+                continue;
+            }
+
+            $record = (object)[
+                'courseid' => $aggregate['courseid'],
+                'userid' => $aggregate['userid'],
+                'timecreated' => $aggregate['timecreated'],
+                'event_count' => $aggregate['event_count'],
+                'last_log_id' => $aggregate['last_log_id'],
+            ];
+
+            if ($aggregate['id'] > 0) {
+                $record->id = $aggregate['id'];
+                $DB->update_record(self::TABLE, $record);
+            } else {
+                $DB->insert_record(self::TABLE, $record);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the highest aggregated log timestamp for a course.
+     *
+     * @param int $courseid
+     * @return int
+     */
+    public static function get_last_aggregated_timecreated(int $courseid): int {
+        global $DB;
+
+        if ($courseid <= 0) {
+            return 0;
+        }
+
+        $sql = "SELECT MAX(timecreated)
+                  FROM {" . self::TABLE . "}
+                 WHERE courseid = :courseid";
+        return (int)$DB->get_field_sql($sql, ['courseid' => $courseid]);
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -51,6 +51,9 @@ class provider implements
     /** @var string */
     private const RISK_TABLE = 'block_student_engagement_risk';
 
+    /** @var string */
+    private const LOG_AGG_TABLE = 'block_student_engagement_log_agg';
+
     /**
      * Describe stored personal data.
      *
@@ -73,6 +76,7 @@ class provider implements
             'risk_level' => 'privacy:metadata:block_student_engagement_risk:risk_level',
             'risk_flags' => 'privacy:metadata:block_student_engagement_risk:risk_flags',
             'last_calculated' => 'privacy:metadata:block_student_engagement_risk:last_calculated',
+            'last_activity_timecreated' => 'privacy:metadata:block_student_engagement_risk:last_activity_timecreated',
         ], 'privacy:metadata:block_student_engagement_risk');
 
         $collection->add_database_table(self::CACHE_TABLE, [
@@ -81,7 +85,17 @@ class provider implements
             'inactive_userids' => 'privacy:metadata:block_student_engagement_cache:inactive_userids',
             'last_calculated' => 'privacy:metadata:block_student_engagement_cache:last_calculated',
             'risk_last_calculated' => 'privacy:metadata:block_student_engagement_cache:risk_last_calculated',
+            'last_log_id' => 'privacy:metadata:block_student_engagement_cache:last_log_id',
+            'last_log_timecreated' => 'privacy:metadata:block_student_engagement_cache:last_log_timecreated',
         ], 'privacy:metadata:block_student_engagement_cache');
+
+        $collection->add_database_table(self::LOG_AGG_TABLE, [
+            'courseid' => 'privacy:metadata:block_student_engagement_log_agg:courseid',
+            'userid' => 'privacy:metadata:block_student_engagement_log_agg:userid',
+            'timecreated' => 'privacy:metadata:block_student_engagement_log_agg:timecreated',
+            'event_count' => 'privacy:metadata:block_student_engagement_log_agg:event_count',
+            'last_log_id' => 'privacy:metadata:block_student_engagement_log_agg:last_log_id',
+        ], 'privacy:metadata:block_student_engagement_log_agg');
 
         return $collection;
     }
@@ -107,6 +121,19 @@ class provider implements
                  ON r.courseid = ctx.instanceid
               WHERE ctx.contextlevel = :contextlevel
                 AND r.userid = :userid",
+            [
+                'contextlevel' => CONTEXT_COURSE,
+                'userid' => $userid,
+            ]
+        );
+
+        $contextlist->add_from_sql(
+            "SELECT ctx.id
+               FROM {context} ctx
+               JOIN {" . self::LOG_AGG_TABLE . "} la
+                 ON la.courseid = ctx.instanceid
+              WHERE ctx.contextlevel = :contextlevel
+                AND la.userid = :userid",
             [
                 'contextlevel' => CONTEXT_COURSE,
                 'userid' => $userid,
@@ -169,6 +196,14 @@ class provider implements
             }
         }
 
+        $logrecords = $DB->get_records(self::LOG_AGG_TABLE, ['courseid' => $courseid], '', 'userid');
+        foreach ($logrecords as $record) {
+            $userid = (int)$record->userid;
+            if ($userid > 0) {
+                $userlist->add_user($userid);
+            }
+        }
+
         $cache = $DB->get_record(self::CACHE_TABLE, ['courseid' => $courseid], 'most_active_userid,inactive_userids', IGNORE_MISSING);
         if (!$cache) {
             return;
@@ -211,7 +246,7 @@ class provider implements
                 self::RISK_TABLE,
                 ['courseid' => $courseid, 'userid' => $userid],
                 'current_grade,pass_grade,grade_gap,completion_percent,days_inactive,recent_events,attendance_percent,engagement_score,' .
-                    'risk_score,risk_level,risk_flags,last_calculated',
+                    'risk_score,risk_level,risk_flags,last_calculated,last_activity_timecreated',
                 IGNORE_MISSING
             );
             if ($risk) {
@@ -243,6 +278,19 @@ class provider implements
                     );
                 }
             }
+
+            $logaggs = $DB->get_records(
+                self::LOG_AGG_TABLE,
+                ['courseid' => $courseid, 'userid' => $userid],
+                'timecreated ASC',
+                'timecreated,event_count,last_log_id'
+            );
+            if (!empty($logaggs)) {
+                writer::with_context($context)->export_data(
+                    [get_string('privacy:export:log_aggregates', 'block_student_engagement')],
+                    (object)['log_aggregates' => array_values($logaggs)]
+                );
+            }
         }
     }
 
@@ -266,6 +314,7 @@ class provider implements
 
         $DB->delete_records(self::RISK_TABLE, ['courseid' => $courseid]);
         $DB->delete_records(self::CACHE_TABLE, ['courseid' => $courseid]);
+        $DB->delete_records(self::LOG_AGG_TABLE, ['courseid' => $courseid]);
     }
 
     /**
@@ -293,6 +342,7 @@ class provider implements
             }
 
             $DB->delete_records(self::RISK_TABLE, ['courseid' => $courseid, 'userid' => $userid]);
+            $DB->delete_records(self::LOG_AGG_TABLE, ['courseid' => $courseid, 'userid' => $userid]);
             self::remove_user_from_cache_record($courseid, [$userid]);
         }
     }
@@ -320,6 +370,7 @@ class provider implements
         list($insql, $params) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
         $params['courseid'] = $courseid;
         $DB->delete_records_select(self::RISK_TABLE, "courseid = :courseid AND userid {$insql}", $params);
+        $DB->delete_records_select(self::LOG_AGG_TABLE, "courseid = :courseid AND userid {$insql}", $params);
         self::remove_user_from_cache_record($courseid, $userids);
     }
 

--- a/classes/task/calculate_engagement.php
+++ b/classes/task/calculate_engagement.php
@@ -62,12 +62,25 @@ class calculate_engagement extends \core\task\scheduled_task {
         $recordset = $DB->get_recordset_select('course', $select, $params, 'id ASC', 'id, fullname');
 
         foreach ($recordset as $course) {
+            $transaction = null;
             try {
-                $payload = \block_student_engagement\engagement_analyser::analyse_course((int)$course->id);
+                $courseid = (int)$course->id;
+                $cache = \block_student_engagement\cache_manager::get_course_cache($courseid);
+                $lastlogid = $cache ? (int)($cache->last_log_id ?? 0) : 0;
+                $lastlogtimecreated = $cache ? (int)($cache->last_log_timecreated ?? 0) : 0;
+
+                $transaction = $DB->start_delegated_transaction();
+
+                $logcursor = \block_student_engagement\logstore_aggregator::sync_course($courseid, $lastlogid);
+                $payload = \block_student_engagement\engagement_analyser::analyse_course($courseid);
+                $payload->last_log_id = (int)$logcursor->last_log_id;
+                $payload->last_log_timecreated = ((int)$logcursor->last_log_timecreated > 0)
+                    ? (int)$logcursor->last_log_timecreated
+                    : $lastlogtimecreated;
 
                 if ($this->is_risk_enabled()) {
-                    $riskresult = \block_student_engagement\local\risk_analyser::analyse_course((int)$course->id);
-                    \block_student_engagement\local\risk_analyser::upsert_course_risk((int)$course->id, $riskresult['rows']);
+                    $riskresult = \block_student_engagement\local\risk_analyser::analyse_course($courseid);
+                    \block_student_engagement\local\risk_analyser::upsert_course_risk($courseid, $riskresult['rows']);
                     $payload->at_risk_count = (int)$riskresult['aggregates']['at_risk_count'];
                     $payload->critical_risk_count = (int)$riskresult['aggregates']['critical_risk_count'];
                     $payload->average_completion_percent = (int)$riskresult['aggregates']['average_completion_percent'];
@@ -75,8 +88,17 @@ class calculate_engagement extends \core\task\scheduled_task {
                 }
 
                 \block_student_engagement\cache_manager::save_course_engagement($payload);
+                $transaction->allow_commit();
+                $transaction = null;
                 mtrace('Updated engagement cache for course ' . (int)$course->id . ': ' . $course->fullname);
             } catch (\Throwable $exception) {
+                if ($transaction !== null) {
+                    try {
+                        $transaction->rollback($exception);
+                    } catch (\Throwable $rollbackexception) {
+                        $exception = $rollbackexception;
+                    }
+                }
                 // Continue processing the remaining courses even if one course fails.
                 mtrace(
                     'Failed to update engagement cache for course ' . (int)$course->id . ': ' .

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- @Author Bastian Coquedano -->
-<XMLDB PATH="blocks/student_engagement/db" VERSION="2026040400" COMMENT="XMLDB file for block_student_engagement"
+<XMLDB PATH="blocks/student_engagement/db" VERSION="2026040800" COMMENT="XMLDB file for block_student_engagement"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,6 +19,8 @@
         <FIELD NAME="critical_risk_count" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
         <FIELD NAME="average_completion_percent" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
         <FIELD NAME="risk_last_calculated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="last_log_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="last_log_timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -45,6 +47,7 @@
         <FIELD NAME="risk_level" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
         <FIELD NAME="risk_flags" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="last_calculated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="last_activity_timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -54,6 +57,23 @@
         <INDEX NAME="course_risk_level_ix" UNIQUE="false" FIELDS="courseid, risk_level"/>
         <INDEX NAME="course_risk_score_ix" UNIQUE="false" FIELDS="courseid, risk_score"/>
         <INDEX NAME="last_calculated_ix" UNIQUE="false" FIELDS="last_calculated"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="block_student_engagement_log_agg" COMMENT="Aggregated logstore events by course, user and timestamp">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="event_count" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="last_log_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="course_user_time_uix" UNIQUE="true" FIELDS="courseid, userid, timecreated"/>
+        <INDEX NAME="course_time_ix" UNIQUE="false" FIELDS="courseid, timecreated"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -137,5 +137,50 @@ function xmldb_block_student_engagement_upgrade(int $oldversion): bool {
         upgrade_block_savepoint(true, 2026040400, 'student_engagement');
     }
 
+    if ($oldversion < 2026040800) {
+        $cachetable = new xmldb_table('block_student_engagement_cache');
+
+        $lastlogid = new xmldb_field('last_log_id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($cachetable, $lastlogid)) {
+            $dbman->add_field($cachetable, $lastlogid);
+        }
+
+        $lastlogtimecreated = new xmldb_field('last_log_timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($cachetable, $lastlogtimecreated)) {
+            $dbman->add_field($cachetable, $lastlogtimecreated);
+        }
+
+        $risktable = new xmldb_table('block_student_engagement_risk');
+        $lastactivity = new xmldb_field('last_activity_timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($risktable, $lastactivity)) {
+            $dbman->add_field($risktable, $lastactivity);
+        }
+
+        $logaggtable = new xmldb_table('block_student_engagement_log_agg');
+        $logaggtable->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $logaggtable->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $logaggtable->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $logaggtable->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $logaggtable->add_field('event_count', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $logaggtable->add_field('last_log_id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $logaggtable->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        if (!$dbman->table_exists($logaggtable)) {
+            $dbman->create_table($logaggtable);
+        }
+
+        $courseusertimeindex = new xmldb_index('course_user_time_uix', XMLDB_INDEX_UNIQUE, ['courseid', 'userid', 'timecreated']);
+        if (!$dbman->index_exists($logaggtable, $courseusertimeindex)) {
+            $dbman->add_index($logaggtable, $courseusertimeindex);
+        }
+
+        $coursetimeindex = new xmldb_index('course_time_ix', XMLDB_INDEX_NOTUNIQUE, ['courseid', 'timecreated']);
+        if (!$dbman->index_exists($logaggtable, $coursetimeindex)) {
+            $dbman->add_index($logaggtable, $coursetimeindex);
+        }
+
+        upgrade_block_savepoint(true, 2026040800, 'student_engagement');
+    }
+
     return true;
 }

--- a/lang/en/block_student_engagement.php
+++ b/lang/en/block_student_engagement.php
@@ -159,6 +159,8 @@ $string['privacy:metadata:block_student_engagement_risk:risk_score'] = 'Calculat
 $string['privacy:metadata:block_student_engagement_risk:risk_level'] = 'Calculated risk level.';
 $string['privacy:metadata:block_student_engagement_risk:risk_flags'] = 'Risk factor flags explaining the result.';
 $string['privacy:metadata:block_student_engagement_risk:last_calculated'] = 'Timestamp when risk data was last calculated.';
+$string['privacy:metadata:block_student_engagement_risk:last_activity_timecreated'] =
+    'Timestamp of the latest activity used for inactivity calculations.';
 
 $string['privacy:metadata:block_student_engagement_cache'] = 'Stores course-level engagement cache with user references.';
 $string['privacy:metadata:block_student_engagement_cache:courseid'] = 'Course ID associated with the cache.';
@@ -166,6 +168,18 @@ $string['privacy:metadata:block_student_engagement_cache:most_active_userid'] = 
 $string['privacy:metadata:block_student_engagement_cache:inactive_userids'] = 'JSON list of user IDs considered inactive in the cached period.';
 $string['privacy:metadata:block_student_engagement_cache:last_calculated'] = 'Timestamp when engagement cache was last refreshed.';
 $string['privacy:metadata:block_student_engagement_cache:risk_last_calculated'] = 'Timestamp when risk aggregates were last refreshed.';
+$string['privacy:metadata:block_student_engagement_cache:last_log_id'] =
+    'Last standard log ID successfully processed for the course cache.';
+$string['privacy:metadata:block_student_engagement_cache:last_log_timecreated'] =
+    'Timestamp of the last standard log entry successfully processed for the course cache.';
+$string['privacy:metadata:block_student_engagement_log_agg'] =
+    'Stores aggregated standard log activity by course, user and timestamp.';
+$string['privacy:metadata:block_student_engagement_log_agg:courseid'] = 'Course ID associated with the aggregated log activity.';
+$string['privacy:metadata:block_student_engagement_log_agg:userid'] = 'User ID associated with the aggregated log activity.';
+$string['privacy:metadata:block_student_engagement_log_agg:timecreated'] = 'Timestamp bucket for aggregated log activity.';
+$string['privacy:metadata:block_student_engagement_log_agg:event_count'] = 'Number of log events aggregated for the timestamp.';
+$string['privacy:metadata:block_student_engagement_log_agg:last_log_id'] = 'Highest standard log ID included in the aggregate row.';
 
 $string['privacy:export:risk'] = 'Academic risk data';
 $string['privacy:export:cache_references'] = 'Course cache references';
+$string['privacy:export:log_aggregates'] = 'Aggregated log activity';

--- a/lang/es/block_student_engagement.php
+++ b/lang/es/block_student_engagement.php
@@ -159,6 +159,8 @@ $string['privacy:metadata:block_student_engagement_risk:risk_score'] = 'Puntaje 
 $string['privacy:metadata:block_student_engagement_risk:risk_level'] = 'Nivel de riesgo calculado.';
 $string['privacy:metadata:block_student_engagement_risk:risk_flags'] = 'Factores de riesgo que explican el resultado.';
 $string['privacy:metadata:block_student_engagement_risk:last_calculated'] = 'Marca de tiempo del ultimo calculo de riesgo.';
+$string['privacy:metadata:block_student_engagement_risk:last_activity_timecreated'] =
+    'Marca de tiempo de la ultima actividad usada para calcular inactividad.';
 
 $string['privacy:metadata:block_student_engagement_cache'] = 'Almacena cache de engagement por curso con referencias de usuario.';
 $string['privacy:metadata:block_student_engagement_cache:courseid'] = 'ID del curso asociado al cache.';
@@ -166,6 +168,20 @@ $string['privacy:metadata:block_student_engagement_cache:most_active_userid'] = 
 $string['privacy:metadata:block_student_engagement_cache:inactive_userids'] = 'Lista JSON de IDs de usuarios considerados inactivos en el periodo cacheado.';
 $string['privacy:metadata:block_student_engagement_cache:last_calculated'] = 'Marca de tiempo de la ultima actualizacion del cache de engagement.';
 $string['privacy:metadata:block_student_engagement_cache:risk_last_calculated'] = 'Marca de tiempo de la ultima actualizacion de agregados de riesgo.';
+$string['privacy:metadata:block_student_engagement_cache:last_log_id'] =
+    'Ultimo ID de log estandar procesado correctamente para el cache del curso.';
+$string['privacy:metadata:block_student_engagement_cache:last_log_timecreated'] =
+    'Marca de tiempo del ultimo log estandar procesado correctamente para el cache del curso.';
+$string['privacy:metadata:block_student_engagement_log_agg'] =
+    'Almacena actividad de log estandar agregada por curso, usuario y marca de tiempo.';
+$string['privacy:metadata:block_student_engagement_log_agg:courseid'] = 'ID del curso asociado a la actividad de log agregada.';
+$string['privacy:metadata:block_student_engagement_log_agg:userid'] = 'ID del usuario asociado a la actividad de log agregada.';
+$string['privacy:metadata:block_student_engagement_log_agg:timecreated'] =
+    'Marca de tiempo usada como bucket para la actividad de log agregada.';
+$string['privacy:metadata:block_student_engagement_log_agg:event_count'] =
+    'Cantidad de eventos de log agregados para la marca de tiempo.';
+$string['privacy:metadata:block_student_engagement_log_agg:last_log_id'] = 'Mayor ID de log estandar incluido en la fila agregada.';
 
 $string['privacy:export:risk'] = 'Datos de riesgo academico';
 $string['privacy:export:cache_references'] = 'Referencias en cache del curso';
+$string['privacy:export:log_aggregates'] = 'Actividad de log agregada';

--- a/tests/logstore_aggregator_test.php
+++ b/tests/logstore_aggregator_test.php
@@ -1,0 +1,254 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Incremental logstore aggregation tests.
+ *
+ * @package    block_student_engagement
+ * @copyright  2026 Bastian Coquedano
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_student_engagement;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Regression tests for incremental logstore cache aggregation.
+ */
+final class logstore_aggregator_test extends \advanced_testcase {
+
+    /**
+     * Initial sync should aggregate valid logs and skip course_viewed noise.
+     *
+     * @return void
+     */
+    public function test_sync_course_aggregates_initial_logs_and_skips_course_viewed(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        [$course, $user] = $this->create_course_student();
+        $time = time() - HOURSECS;
+
+        $firstid = $this->insert_standard_log((int)$course->id, (int)$user->id, $time);
+        $secondid = $this->insert_standard_log((int)$course->id, (int)$user->id, $time);
+        $this->insert_standard_log((int)$course->id, (int)$user->id, $time, '\\core\\event\\course_viewed');
+
+        $cursor = logstore_aggregator::sync_course((int)$course->id, 0);
+        $aggregates = $DB->get_records(logstore_aggregator::TABLE, ['courseid' => (int)$course->id]);
+
+        $this->assertSame(2, (int)$cursor->processed_events);
+        $this->assertSame($secondid, (int)$cursor->last_log_id);
+        $this->assertSame($time, (int)$cursor->last_log_timecreated);
+        $this->assertCount(1, $aggregates);
+
+        $aggregate = reset($aggregates);
+        $this->assertSame((int)$user->id, (int)$aggregate->userid);
+        $this->assertSame($time, (int)$aggregate->timecreated);
+        $this->assertSame(2, (int)$aggregate->event_count);
+        $this->assertSame($secondid, (int)$aggregate->last_log_id);
+
+        $this->assertGreaterThanOrEqual($firstid, (int)$aggregate->last_log_id);
+    }
+
+    /**
+     * Reprocessing with a stale cursor should not duplicate aggregate counts.
+     *
+     * @return void
+     */
+    public function test_sync_course_is_idempotent_when_cursor_is_stale(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        [$course, $user] = $this->create_course_student();
+        $time = time() - HOURSECS;
+
+        $this->insert_standard_log((int)$course->id, (int)$user->id, $time);
+        $lastid = $this->insert_standard_log((int)$course->id, (int)$user->id, $time);
+
+        logstore_aggregator::sync_course((int)$course->id, 0);
+        $cursor = logstore_aggregator::sync_course((int)$course->id, 0);
+
+        $aggregate = $DB->get_record(logstore_aggregator::TABLE, ['courseid' => (int)$course->id], '*', MUST_EXIST);
+        $this->assertSame(0, (int)$cursor->processed_events);
+        $this->assertSame($lastid, (int)$cursor->last_log_id);
+        $this->assertSame($time, (int)$cursor->last_log_timecreated);
+        $this->assertSame(2, (int)$aggregate->event_count);
+        $this->assertSame($lastid, (int)$aggregate->last_log_id);
+    }
+
+    /**
+     * Engagement cache should read activity windows from aggregate rows.
+     *
+     * @return void
+     */
+    public function test_engagement_analyser_reads_activity_windows_from_aggregates(): void {
+        $this->resetAfterTest(true);
+        [$course, $activeuser] = $this->create_course_student();
+        $inactiveuser = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user((int)$inactiveuser->id, (int)$course->id, 'student');
+
+        set_config('active_days_threshold', 7, 'block_student_engagement');
+        set_config('inactive_days_threshold', 14, 'block_student_engagement');
+
+        $recenttime = time() - DAYSECS;
+        $oldtime = time() - (30 * DAYSECS);
+        $this->insert_standard_log((int)$course->id, (int)$activeuser->id, $recenttime);
+        $this->insert_standard_log((int)$course->id, (int)$activeuser->id, $recenttime);
+        $this->insert_standard_log((int)$course->id, (int)$inactiveuser->id, $oldtime);
+        logstore_aggregator::sync_course((int)$course->id, 0);
+
+        $payload = engagement_analyser::analyse_course((int)$course->id);
+
+        $this->assertSame(1, (int)$payload->active_students);
+        $this->assertSame(1, (int)$payload->inactive_students);
+        $this->assertSame((int)$activeuser->id, (int)$payload->most_active_userid);
+        $this->assertSame(2, (int)$payload->most_active_interactions);
+    }
+
+    /**
+     * Risk analyser should keep last activity derived from aggregate rows.
+     *
+     * @return void
+     */
+    public function test_risk_analyser_uses_aggregated_last_activity(): void {
+        $this->resetAfterTest(true);
+        [$course, $user] = $this->create_course_student();
+        $time = time() - DAYSECS;
+
+        $this->insert_standard_log((int)$course->id, (int)$user->id, $time);
+        logstore_aggregator::sync_course((int)$course->id, 0);
+
+        $result = \block_student_engagement\local\risk_analyser::analyse_course((int)$course->id);
+
+        $this->assertNotEmpty($result['rows']);
+        $row = reset($result['rows']);
+        $this->assertSame((int)$user->id, (int)$row['userid']);
+        $this->assertSame($time, (int)$row['last_activity_timecreated']);
+        $this->assertGreaterThanOrEqual(0, (int)$row['days_inactive']);
+    }
+
+    /**
+     * Cache persistence should keep the confirmed log cursor.
+     *
+     * @return void
+     */
+    public function test_cache_manager_persists_log_cursor(): void {
+        $this->resetAfterTest(true);
+        $course = $this->getDataGenerator()->create_course();
+
+        cache_manager::save_course_engagement((object)[
+            'courseid' => (int)$course->id,
+            'last_log_id' => 123,
+            'last_log_timecreated' => 456,
+        ]);
+
+        $cache = cache_manager::get_course_cache((int)$course->id);
+        $this->assertNotNull($cache);
+        $this->assertSame(123, (int)$cache->last_log_id);
+        $this->assertSame(456, (int)$cache->last_log_timecreated);
+    }
+
+    /**
+     * Rollback should keep aggregates and confirmed cursor unchanged.
+     *
+     * @return void
+     */
+    public function test_transaction_rollback_keeps_cursor_unconfirmed(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        [$course, $user] = $this->create_course_student();
+        $this->insert_standard_log((int)$course->id, (int)$user->id, time() - HOURSECS);
+
+        $transaction = $DB->start_delegated_transaction();
+        try {
+            $cursor = logstore_aggregator::sync_course((int)$course->id, 0);
+            cache_manager::save_course_engagement((object)[
+                'courseid' => (int)$course->id,
+                'last_log_id' => (int)$cursor->last_log_id,
+                'last_log_timecreated' => (int)$cursor->last_log_timecreated,
+            ]);
+            throw new \coding_exception('Simulated failure after aggregation');
+        } catch (\Throwable $exception) {
+            try {
+                $transaction->rollback($exception);
+            } catch (\Throwable $rollbackexception) {
+                // Moodle rethrows the original exception after rolling back.
+            }
+        }
+
+        $this->assertFalse($DB->record_exists(logstore_aggregator::TABLE, ['courseid' => (int)$course->id]));
+        $this->assertNull(cache_manager::get_course_cache((int)$course->id));
+    }
+
+    /**
+     * Create a course and one enrolled student.
+     *
+     * @return array{\stdClass,\stdClass}
+     */
+    private function create_course_student(): array {
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user((int)$user->id, (int)$course->id, 'student');
+
+        return [$course, $user];
+    }
+
+    /**
+     * Insert a minimal standard log row.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @param int $timecreated
+     * @param string $eventname
+     * @return int
+     */
+    private function insert_standard_log(
+        int $courseid,
+        int $userid,
+        int $timecreated,
+        string $eventname = '\\mod_forum\\event\\course_module_viewed'
+    ): int {
+        global $DB;
+
+        $context = \context_course::instance($courseid);
+        $record = (object)[
+            'eventname' => $eventname,
+            'component' => 'mod_forum',
+            'action' => 'viewed',
+            'target' => 'course_module',
+            'objecttable' => null,
+            'objectid' => null,
+            'crud' => 'r',
+            'edulevel' => 2,
+            'contextid' => $context->id,
+            'contextlevel' => CONTEXT_COURSE,
+            'contextinstanceid' => $courseid,
+            'userid' => $userid,
+            'courseid' => $courseid,
+            'relateduserid' => null,
+            'anonymous' => 0,
+            'other' => null,
+            'timecreated' => $timecreated,
+            'origin' => 'cli',
+            'ip' => null,
+            'realuserid' => null,
+        ];
+
+        return (int)$DB->insert_record('logstore_standard_log', $record);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026040401; // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026040800; // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2024100100; // Requires this Moodle version (4.5).
 $plugin->component = 'block_student_engagement';


### PR DESCRIPTION
## Resumen
- Agrega una tabla agregada `block_student_engagement_log_agg` para procesar solo eventos nuevos de `logstore_standard_log` por curso.
- Agrega curso-cursor en `block_student_engagement_cache` (`last_log_id`, `last_log_timecreated`) y `last_activity_timecreated` en riesgo.
- Cambia `engagement_analyser` y `risk_analyser` para leer ventanas de actividad desde agregados locales.
- Envuelve el procesamiento por curso del cron en transacción antes de confirmar el cursor.
- Actualiza metadata privacy, strings EN/ES y tests de agregación incremental.

## Validación
- `docker exec moodle_web php -l` sobre los PHP modificados y nuevos: OK
- `git diff --check`: OK

No se ejecutó PHPUnit completo porque `phpunit` no está disponible en `PATH` ni existe `/var/www/html/vendor/bin/phpunit` en el contenedor.

## Riesgos / revisión manual
- Validar `admin/cli/upgrade.php` en una instalación real para crear tabla/campos nuevos.
- Ejecutar el cron con cursos con logs históricos para revisar cursor, agregados y métricas de ventana.

Closes #41
